### PR TITLE
Deprecate unescape and use decodeURIComponent

### DIFF
--- a/md5.js
+++ b/md5.js
@@ -11,7 +11,7 @@
  * @return {string} The hexadecimal hash string that is handled and converted.
  */
 module.exports = data => {
-    const stringUTF8 = unescape(encodeURIComponent(data));
+    const stringUTF8 = decodeURIComponent(encodeURIComponent(data));
 
     const stringNumArr = rstr2binl(stringUTF8);
 

--- a/test/test.js
+++ b/test/test.js
@@ -5,18 +5,20 @@ const assert = require('assert');
 
 const md5 = require('../md5');
 
-// Instance Object for Testing
+// Instance object for testing
 const example = {
     name: 'xn-02f',
     email: 'i@huiyifyj.cn',
-    url: 'xn--02f.com'
+    url: 'xn--02f.com',
+    uriReserved: ';/?:@&=+$,'
 }
 
-// Related MD5 Hash Value
+// Related MD5 hash value
 const md5Hash = {
     name: '54d30fa674d13e3598970bc9c5e2388e',
     email: '11b334f003ef029c9d154f5dbae18b44',
-    url: '014dab5b5a990d379b2306f5d0839261'
+    url: '014dab5b5a990d379b2306f5d0839261',
+    uriReserved: 'cae1061daebd7e3700817d67a2727fc2'
 }
 
 describe('MD5 Test', () => {
@@ -30,5 +32,11 @@ describe('MD5 Test', () => {
 
     it('"' + example.url + '" Converted to MD5 Value Test.', () => {
         assert.equal(md5(example.url), md5Hash.url);
+    });
+});
+
+describe('Special Strings Test', () => {
+    it('Test reserved characters of URI: "' + example.uriReserved + '".', () => {
+        assert.equal(md5(example.uriReserved), md5Hash.uriReserved);
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,7 @@ const example = {
     name: 'xn-02f',
     email: 'i@huiyifyj.cn',
     url: 'xn--02f.com',
+    chinese: '中文',
     uriReserved: ';/?:@&=+$,'
 }
 
@@ -18,6 +19,7 @@ const md5Hash = {
     name: '54d30fa674d13e3598970bc9c5e2388e',
     email: '11b334f003ef029c9d154f5dbae18b44',
     url: '014dab5b5a990d379b2306f5d0839261',
+    chinese: 'a7bac2239fcdcb3a067903d8077c4a07',
     uriReserved: 'cae1061daebd7e3700817d67a2727fc2'
 }
 
@@ -38,5 +40,9 @@ describe('MD5 Test', () => {
 describe('Special Strings Test', () => {
     it('Test reserved characters of URI: "' + example.uriReserved + '".', () => {
         assert.equal(md5(example.uriReserved), md5Hash.uriReserved);
+    });
+
+    it('Test chinese string "' + example.chinese + '".', () => {
+        assert.equal(md5(example.chinese), md5Hash.chinese);
     });
 });


### PR DESCRIPTION
This PR will replacing `unescape()` with `decodeURIComponent()`.
Open the PR for issue #10.