### PR TITLE
Add reserved characters of URI and chinese test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -5,18 +5,20 @@ const assert = require('assert');
 
 const md5 = require('../md5');
 
-// Instance Object for Testing
+// Instance object for testing
 const example = {
     name: 'xn-02f',
     email: 'i@huiyifyj.cn',
-    url: 'xn--02f.com'
+    url: 'xn--02f.com',
+    uriReserved: ';/?:@&=+$,'
 }
 
-// Related MD5 Hash Value
+// Related MD5 hash value
 const md5Hash = {
     name: '54d30fa674d13e3598970bc9c5e2388e',
     email: '11b334f003ef029c9d154f5dbae18b44',
-    url: '014dab5b5a990d379b2306f5d0839261'
+    url: '014dab5b5a990d379b2306f5d0839261',
+    uriReserved: 'cae1061daebd7e3700817d67a2727fc2'
 }
 
 describe('MD5 Test', () => {
@@ -30,5 +32,11 @@ describe('MD5 Test', () => {
 
     it('"' + example.url + '" Converted to MD5 Value Test.', () => {
         assert.equal(md5(example.url), md5Hash.url);
+    });
+});
+
+describe('Special Strings Test', () => {
+    it('Test reserved characters of URI: "' + example.uriReserved + '".', () => {
+        assert.equal(md5(example.uriReserved), md5Hash.uriReserved);
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,7 @@ const example = {
     name: 'xn-02f',
     email: 'i@huiyifyj.cn',
     url: 'xn--02f.com',
+    chinese: '中文',
     uriReserved: ';/?:@&=+$,'
 }
 
@@ -18,6 +19,7 @@ const md5Hash = {
     name: '54d30fa674d13e3598970bc9c5e2388e',
     email: '11b334f003ef029c9d154f5dbae18b44',
     url: '014dab5b5a990d379b2306f5d0839261',
+    chinese: 'a7bac2239fcdcb3a067903d8077c4a07',
     uriReserved: 'cae1061daebd7e3700817d67a2727fc2'
 }
 
@@ -38,5 +40,9 @@ describe('MD5 Test', () => {
 describe('Special Strings Test', () => {
     it('Test reserved characters of URI: "' + example.uriReserved + '".', () => {
         assert.equal(md5(example.uriReserved), md5Hash.uriReserved);
+    });
+
+    it('Test chinese string "' + example.chinese + '".', () => {
+        assert.equal(md5(example.chinese), md5Hash.chinese);
     });
 });


### PR DESCRIPTION
Open the PR for https://github.com/xn-02f/md5/pull/14#issuecomment-602003298

- Add special string test.
  Test reserved characters of URI: `;` `/` `?` `:` `@` `&` `=` `+` `$` `,`.
  More informations to [URI Handling Function Properties](https://ecma-international.org/ecma-262/5.1/#sec-15.1.3).
- Add chinese string test.
- Update annotation.