### PR TITLE
Switch default branch to `main` and rename test file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Via npm :
 
 ```bash
-$ npm i @xn-02f/md5
+npm i @xn-02f/md5
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MD5
 
-[![GithubActions](https://img.shields.io/github/actions/workflow/status/xn-02f/md5/test.yml?style=flat-square&logo=github)](https://github.com/xn-02f/md5/actions)
+[![Actions](https://img.shields.io/github/actions/workflow/status/xn-02f/md5/test.yml?style=flat-square&logo=github)](https://github.com/xn-02f/md5/actions)
 [![npm](https://img.shields.io/npm/v/@xn-02f/md5.svg?style=flat-square&logo=npm)](https://www.npmjs.com/package/@xn-02f/md5)
-[![LICENSE](https://img.shields.io/github/license/xn-02f/md5.svg?style=flat-square&logo=opensourceinitiative)](https://github.com/xn-02f/md5/blob/master/LICENSE)
+[![LICENSE](https://img.shields.io/github/license/xn-02f/md5.svg?style=flat-square&logo=opensourceinitiative)](https://github.com/xn-02f/md5/blob/main/LICENSE)
 > 🔓 `MD5` is tiny library without dependencies for node, convert string to MD5 hash.
 
 ## Install
@@ -28,7 +28,7 @@ Parameter | return
 
 ### License
 
-> [MIT](https://github.com/xn-02f/md5/blob/master/LICENSE)
+> [MIT](https://github.com/xn-02f/md5/blob/main/LICENSE)
 
 <br>
 <br>

--- a/test/md5.test.js
+++ b/test/md5.test.js
@@ -1,9 +1,9 @@
 /*
  * This file is used to test.
  */
-import test from 'ava';
+const test = require('ava');
 
-import md5 from '../md5.js';
+const md5 = require('../md5');
 
 // Instance object for testing
 const example = {
@@ -11,7 +11,6 @@ const example = {
     email: 'i@huiyifyj.cn',
     url: 'xn--02f.com',
     chinese: '中文',
-    unicode: '\u4f60\u597d',
     uriReserved: ';/?:@&=+$,'
 }
 
@@ -21,7 +20,6 @@ const md5Hash = {
     email: '11b334f003ef029c9d154f5dbae18b44',
     url: '014dab5b5a990d379b2306f5d0839261',
     chinese: 'a7bac2239fcdcb3a067903d8077c4a07',
-    unicode: '7eca689f0d3389d9dea66ae112e5cfd7',
     uriReserved: 'cae1061daebd7e3700817d67a2727fc2'
 }
 

--- a/test/md5.test.js
+++ b/test/md5.test.js
@@ -1,9 +1,9 @@
 /*
  * This file is used to test.
  */
-const test = require('ava');
+import test from 'ava';
 
-const md5 = require('../md5');
+import md5 from '../md5.js';
 
 // Instance object for testing
 const example = {
@@ -11,6 +11,7 @@ const example = {
     email: 'i@huiyifyj.cn',
     url: 'xn--02f.com',
     chinese: '中文',
+    unicode: '\u4f60\u597d',
     uriReserved: ';/?:@&=+$,'
 }
 
@@ -20,6 +21,7 @@ const md5Hash = {
     email: '11b334f003ef029c9d154f5dbae18b44',
     url: '014dab5b5a990d379b2306f5d0839261',
     chinese: 'a7bac2239fcdcb3a067903d8077c4a07',
+    unicode: '7eca689f0d3389d9dea66ae112e5cfd7',
     uriReserved: 'cae1061daebd7e3700817d67a2727fc2'
 }
 


### PR DESCRIPTION
- Switch the default branch from `master` to `main`, and update related URL links in README file.
  For refer to https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/
- Remove dollar sign used before commands without showing output.
  For refer to https://github.com/DavidAnson/markdownlint/blob/v0.27.0/doc/md014.md
- Rename test file: `test.js` => `md5.test.js`.