### PR TITLE
Move to ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ npm i @xn-02f/md5
 ## Usage
 
 ```javascript
-const md5 = require('@xn-02f/md5');
-// import md5 from '@xn-02f/md5'
+import md5 from '@xn-02f/md5'
 
 md5('xn-02f');  // => '54d30fa674d13e3598970bc9c5e2388e'
 ```

--- a/md5.d.ts
+++ b/md5.d.ts
@@ -12,4 +12,4 @@
  */
 declare const md5: (data: string) => string;
 
-export = md5;
+export default md5;

--- a/md5.d.ts
+++ b/md5.d.ts
@@ -5,8 +5,7 @@
  * @return {string} The hexadecimal hash string that is handled and converted.
  * @example
  * ```
- * import md5 = require('@xn-02f/md5');
- * // import md5 from '@xn-02f/md5';
+ * import md5 from '@xn-02f/md5';
  * md5('xn-02f'); //=> '54d30fa674d13e3598970bc9c5e2388e'
  * ```
  */

--- a/md5.js
+++ b/md5.js
@@ -11,8 +11,7 @@
  * @return {string} The hexadecimal hash string that is handled and converted.
  * @example
  * ```
- * const md5 = require('@xn-02f/md5');
- * // import md5 from '@xn-02f/md5';
+ * import md5 from '@xn-02f/md5';
  * md5('xn-02f'); //=> '54d30fa674d13e3598970bc9c5e2388e'
  * ```
  */

--- a/md5.js
+++ b/md5.js
@@ -16,7 +16,7 @@
  * md5('xn-02f'); //=> '54d30fa674d13e3598970bc9c5e2388e'
  * ```
  */
-module.exports = data => {
+export default data => {
     const stringUTF8 = unescape(encodeURIComponent(data));
 
     const stringNumArr = rstr2binl(stringUTF8);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "@xn-02f/md5",
   "version": "2.4.4",
   "description": "A tiny MD5 library without dependencies for node, convert string to MD5 hash.",
+  "type": "module",
+  "exports":"./md5.js",
   "main": "md5.js",
   "types": "md5.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.4.4",
   "description": "A tiny MD5 library without dependencies for node, convert string to MD5 hash.",
   "type": "module",
-  "exports":"./md5.js",
+  "exports": "./md5.js",
   "main": "md5.js",
   "types": "md5.d.ts",
   "scripts": {
@@ -25,6 +25,9 @@
   "devDependencies": {
     "ava": "5.x",
     "tsd": "^0.28.1"
+  },
+  "engines": {
+    "node": ">=16"
   },
   "files": [
     "md5.js",

--- a/test/md5.test.js
+++ b/test/md5.test.js
@@ -1,9 +1,9 @@
 /*
  * This file is used to test.
  */
-const test = require('ava');
+import test from 'ava';
 
-const md5 = require('../md5');
+import md5 from '../md5.js';
 
 // Instance object for testing
 const example = {


### PR DESCRIPTION
Migrate [@xn-02f/md5](https://www.npmjs.com/package/@xn-02f/md5) to [ESM](https://nodejs.org/api/esm.html).
> [!WARNING]
> This means that the package is native [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) and no longer provides a CommonJS export.
> And require minimum [nodejs](https://nodejs.org/) version `>=16`.

Refer to below links:
- https://github.com/sindresorhus/meta/discussions/15
- [Pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c)