### PR TITLE
Upgrade actions and node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Run tests
         run: |


### PR DESCRIPTION
Node.js 16 will be deprecated on 09/11/2023, refer to nodejs blog announcements[^1].
GitHub will transition actions to nodejs 20 by Spring 2024, refer to GitHub blog[^2].

Upgrade specified version of node runtime to `20.x` for test.
Update the following actions to use Nodejs 20 runtime:
- actions/checkout: `v3` => `v4` [^3]
- actions/setup-node: `v3` => `v4` [^4]

[^1]: [Bringing forward the End-of-Life Date for Node.js 16](https://nodejs.org/en/blog/announcements/nodejs16-eol)
[^2]: [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20)
[^3]: [actions/checkout **v4** release changelog](https://github.com/actions/checkout/releases/tag/v4.0.0)
[^4]: [actions/setup-node **v4** release changelog](https://github.com/actions/setup-node/releases/tag/v4.0.0)