### PR TITLE
Drop node 18 and bump dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 24
           - 22
           - 20
-          - 18
 
     steps:
       - name: Checkout code

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/xn-02f/md5#readme",
   "devDependencies": {
     "ava": "6.x",
-    "tsd": "^0.31.2"
+    "tsd": "^0.32.0"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
- Drop node.js `18` from the CI workflow as it is no longer supported after 30 April 2025. [^1]
- Bump `tsd` from 0.31.2 to 0.32.0.

[^1]: [Nodejs 18 - Commercial Support](https://nodejs.org/en/about/previous-releases#commercial-support)